### PR TITLE
Move language switcher to top-right with flags

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -274,6 +274,59 @@ body {
   padding: 2.5rem;
   overflow-y: auto;
   min-width: 0;
+  position: relative;
+}
+
+/* Language switcher */
+.language-switcher {
+  position: absolute;
+  top: 1.5rem;
+  right: 1.5rem;
+  display: flex;
+  gap: 0.25rem;
+  background: var(--c-surface);
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius-sm);
+  padding: 0.25rem;
+  box-shadow: var(--shadow-sm);
+  z-index: 10;
+}
+
+.language-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.625rem;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  cursor: pointer;
+  transition: all var(--transition);
+  font-family: inherit;
+}
+
+.language-btn:hover {
+  background: var(--c-bg);
+}
+
+.language-btn.active {
+  background: var(--c-primary-light);
+}
+
+.language-flag {
+  font-size: 1.125rem;
+  line-height: 1;
+}
+
+.language-code {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: var(--c-text-muted);
+  letter-spacing: 0.02em;
+}
+
+.language-btn.active .language-code {
+  color: var(--c-primary);
 }
 
 .page {
@@ -958,6 +1011,20 @@ body {
 
   .content {
     padding: 1.25rem;
+    padding-top: 3.5rem;
+  }
+
+  .language-switcher {
+    top: 0.75rem;
+    right: 0.75rem;
+  }
+
+  .language-code {
+    display: none;
+  }
+
+  .language-btn {
+    padding: 0.375rem 0.5rem;
   }
 
   .page-header h1 {

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -132,15 +132,6 @@ function AppContent() {
           </div>
         </div>
 
-        <div className="sidebar-section">
-          <span className="sidebar-section-label">{t("labelLanguage")}</span>
-          <select value={language} onChange={(e) => setLanguage(e.target.value)}>
-            {LANGUAGES.map((lang) => (
-              <option key={lang.code} value={lang.code}>{lang.name}</option>
-            ))}
-          </select>
-        </div>
-
         <div className="medical-disclaimer">
           <div className="medical-disclaimer-icon">
             <MedicalIcon />
@@ -164,6 +155,19 @@ function AppContent() {
       </aside>
 
       <main className="content">
+        <div className="language-switcher">
+          {LANGUAGES.map((lang) => (
+            <button
+              key={lang.code}
+              className={`language-btn ${language === lang.code ? "active" : ""}`}
+              onClick={() => setLanguage(lang.code)}
+              title={lang.name}
+            >
+              <span className="language-flag">{lang.flag}</span>
+              <span className="language-code">{lang.code.toUpperCase()}</span>
+            </button>
+          ))}
+        </div>
         {data ? (
           <Routes>
             <Route

--- a/web/src/i18n/translations.js
+++ b/web/src/i18n/translations.js
@@ -161,6 +161,6 @@ export const translations = {
 };
 
 export const LANGUAGES = [
-  { code: "en", name: "English" },
-  { code: "es", name: "Español" },
+  { code: "en", name: "English", flag: "🇬🇧" },
+  { code: "es", name: "Español", flag: "🇪🇸" },
 ];


### PR DESCRIPTION
- Move language selector from sidebar to top-right corner
- Add flag emojis for each language (GB, ES)
- Show language code next to flag on desktop
- Responsive: hide code on mobile, show only flags
- Cleaner button-style UI for language selection

https://claude.ai/code/session_01PSh1yB4Ws6yw7HyUwJGQ2D