### PR TITLE
Add coach marks for first-time user onboarding

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1044,3 +1044,189 @@ body {
     align-items: stretch;
   }
 }
+
+/* ── Coach Marks ─────────────────────────────────── */
+.coach-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  pointer-events: none;
+}
+
+.coach-backdrop {
+  position: fixed;
+  inset: 0;
+  pointer-events: auto;
+}
+
+.coach-spotlight {
+  position: fixed;
+  border: 2px solid var(--c-primary);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.2);
+  pointer-events: none;
+  animation: coach-pulse 2s ease-in-out infinite;
+}
+
+@keyframes coach-pulse {
+  0%, 100% {
+    box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.2);
+  }
+  50% {
+    box-shadow: 0 0 0 8px rgba(99, 102, 241, 0.1);
+  }
+}
+
+.coach-tooltip {
+  position: fixed;
+  background: var(--c-surface);
+  border-radius: var(--radius-md);
+  padding: 1.25rem;
+  box-shadow: var(--shadow-lg), 0 0 0 1px var(--c-border);
+  pointer-events: auto;
+  animation: fadeInUp 0.3s ease;
+  z-index: 1001;
+}
+
+.coach-tooltip-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.coach-tooltip-header h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--c-text);
+  margin: 0;
+}
+
+.coach-step-indicator {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--c-text-muted);
+  background: var(--c-bg);
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+}
+
+.coach-tooltip p {
+  font-size: 0.875rem;
+  color: var(--c-text-secondary);
+  line-height: 1.6;
+  margin: 0 0 1rem 0;
+}
+
+.coach-tooltip-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.coach-btn-group {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.coach-btn-skip {
+  padding: 0.5rem 0.75rem;
+  border: none;
+  background: transparent;
+  color: var(--c-text-muted);
+  font-family: inherit;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color var(--transition);
+}
+
+.coach-btn-skip:hover {
+  color: var(--c-text-secondary);
+}
+
+.coach-btn-prev {
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius-sm);
+  background: var(--c-surface);
+  color: var(--c-text-secondary);
+  font-family: inherit;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.coach-btn-prev:hover {
+  background: var(--c-bg);
+  border-color: var(--c-text-muted);
+}
+
+.coach-btn-next {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: var(--c-primary);
+  color: white;
+  font-family: inherit;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.coach-btn-next:hover {
+  background: var(--c-primary-hover);
+}
+
+/* Tooltip arrow positions */
+.coach-tooltip-right::before {
+  content: "";
+  position: absolute;
+  left: -8px;
+  top: 50%;
+  transform: translateY(-50%);
+  border: 8px solid transparent;
+  border-right-color: var(--c-surface);
+  filter: drop-shadow(-2px 0 1px rgba(0, 0, 0, 0.05));
+}
+
+.coach-tooltip-bottom::before {
+  content: "";
+  position: absolute;
+  top: -8px;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 8px solid transparent;
+  border-bottom-color: var(--c-surface);
+  filter: drop-shadow(0 -2px 1px rgba(0, 0, 0, 0.05));
+}
+
+.coach-tooltip-bottom-left::before {
+  content: "";
+  position: absolute;
+  top: -8px;
+  right: 24px;
+  border: 8px solid transparent;
+  border-bottom-color: var(--c-surface);
+  filter: drop-shadow(0 -2px 1px rgba(0, 0, 0, 0.05));
+}
+
+/* Mobile adjustments for coach marks */
+@media (max-width: 768px) {
+  .coach-tooltip {
+    position: fixed !important;
+    bottom: 1rem !important;
+    left: 1rem !important;
+    right: 1rem !important;
+    top: auto !important;
+    transform: none !important;
+    max-width: none !important;
+  }
+
+  .coach-tooltip::before {
+    display: none;
+  }
+}

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -6,6 +6,7 @@ import { LANGUAGES } from "./i18n/translations";
 import Calculator from "./pages/Calculator";
 import Evolution from "./pages/Evolution";
 import UserManual from "./pages/UserManual";
+import CoachMarks from "./components/CoachMarks";
 import "./App.css";
 
 const MEASURES = ["Weight", "Height", "Head Circumference"];
@@ -82,6 +83,7 @@ function AppContent() {
 
   return (
     <div className="layout">
+      <CoachMarks />
       <aside className="sidebar">
         <div className="sidebar-brand">
           <div className="sidebar-brand-icon">

--- a/web/src/components/CoachMarks.jsx
+++ b/web/src/components/CoachMarks.jsx
@@ -1,0 +1,223 @@
+import { useState, useEffect, useCallback } from "react";
+import { useLanguage } from "../i18n/LanguageContext";
+
+const STORAGE_KEY = "baby-growth-coach-completed";
+
+const STEPS = [
+  {
+    target: ".sidebar-brand",
+    position: "right",
+    titleKey: "coachWelcomeTitle",
+    textKey: "coachWelcomeText",
+  },
+  {
+    target: ".sidebar nav",
+    position: "right",
+    titleKey: "coachNavTitle",
+    textKey: "coachNavText",
+  },
+  {
+    target: ".sidebar-section:first-of-type",
+    position: "right",
+    titleKey: "coachMetricTitle",
+    textKey: "coachMetricText",
+  },
+  {
+    target: ".gender-toggle",
+    position: "right",
+    titleKey: "coachGenderTitle",
+    textKey: "coachGenderText",
+  },
+  {
+    target: ".language-switcher",
+    position: "bottom-left",
+    titleKey: "coachLanguageTitle",
+    textKey: "coachLanguageText",
+  },
+  {
+    target: ".medical-disclaimer",
+    position: "right",
+    titleKey: "coachDisclaimerTitle",
+    textKey: "coachDisclaimerText",
+  },
+];
+
+function getElementPosition(selector) {
+  const el = document.querySelector(selector);
+  if (!el) return null;
+  const rect = el.getBoundingClientRect();
+  return {
+    top: rect.top + window.scrollY,
+    left: rect.left + window.scrollX,
+    width: rect.width,
+    height: rect.height,
+    rect,
+  };
+}
+
+export default function CoachMarks() {
+  const { t } = useLanguage();
+  const [currentStep, setCurrentStep] = useState(0);
+  const [isVisible, setIsVisible] = useState(false);
+  const [targetPos, setTargetPos] = useState(null);
+
+  // Check if coach marks should be shown
+  useEffect(() => {
+    try {
+      const completed = localStorage.getItem(STORAGE_KEY);
+      if (!completed) {
+        // Small delay to let the page render
+        const timer = setTimeout(() => setIsVisible(true), 500);
+        return () => clearTimeout(timer);
+      }
+    } catch {
+      // Ignore storage errors
+    }
+  }, []);
+
+  // Update target position when step changes
+  useEffect(() => {
+    if (!isVisible) return;
+
+    const updatePosition = () => {
+      const pos = getElementPosition(STEPS[currentStep].target);
+      setTargetPos(pos);
+    };
+
+    updatePosition();
+    window.addEventListener("resize", updatePosition);
+    return () => window.removeEventListener("resize", updatePosition);
+  }, [currentStep, isVisible]);
+
+  const handleComplete = useCallback(() => {
+    setIsVisible(false);
+    try {
+      localStorage.setItem(STORAGE_KEY, "true");
+    } catch {
+      // Ignore storage errors
+    }
+  }, []);
+
+  const handleNext = useCallback(() => {
+    if (currentStep < STEPS.length - 1) {
+      setCurrentStep((s) => s + 1);
+    } else {
+      handleComplete();
+    }
+  }, [currentStep, handleComplete]);
+
+  const handlePrev = useCallback(() => {
+    if (currentStep > 0) {
+      setCurrentStep((s) => s - 1);
+    }
+  }, [currentStep]);
+
+  const handleSkip = useCallback(() => {
+    handleComplete();
+  }, [handleComplete]);
+
+  if (!isVisible || !targetPos) return null;
+
+  const step = STEPS[currentStep];
+  const padding = 8;
+
+  // Calculate tooltip position
+  let tooltipStyle = {};
+  const tooltipWidth = 320;
+  const tooltipOffset = 16;
+
+  switch (step.position) {
+    case "right":
+      tooltipStyle = {
+        top: targetPos.rect.top + targetPos.height / 2,
+        left: targetPos.rect.right + tooltipOffset,
+        transform: "translateY(-50%)",
+      };
+      break;
+    case "bottom":
+      tooltipStyle = {
+        top: targetPos.rect.bottom + tooltipOffset,
+        left: targetPos.rect.left + targetPos.width / 2,
+        transform: "translateX(-50%)",
+      };
+      break;
+    case "bottom-left":
+      tooltipStyle = {
+        top: targetPos.rect.bottom + tooltipOffset,
+        right: window.innerWidth - targetPos.rect.right,
+      };
+      break;
+    default:
+      tooltipStyle = {
+        top: targetPos.rect.bottom + tooltipOffset,
+        left: targetPos.rect.left,
+      };
+  }
+
+  return (
+    <div className="coach-overlay">
+      {/* Dark overlay with spotlight hole */}
+      <svg className="coach-backdrop" width="100%" height="100%">
+        <defs>
+          <mask id="spotlight-mask">
+            <rect width="100%" height="100%" fill="white" />
+            <rect
+              x={targetPos.rect.left - padding}
+              y={targetPos.rect.top - padding}
+              width={targetPos.width + padding * 2}
+              height={targetPos.height + padding * 2}
+              rx="8"
+              fill="black"
+            />
+          </mask>
+        </defs>
+        <rect
+          width="100%"
+          height="100%"
+          fill="rgba(0, 0, 0, 0.75)"
+          mask="url(#spotlight-mask)"
+        />
+      </svg>
+
+      {/* Spotlight border */}
+      <div
+        className="coach-spotlight"
+        style={{
+          top: targetPos.rect.top - padding,
+          left: targetPos.rect.left - padding,
+          width: targetPos.width + padding * 2,
+          height: targetPos.height + padding * 2,
+        }}
+      />
+
+      {/* Tooltip */}
+      <div
+        className={`coach-tooltip coach-tooltip-${step.position}`}
+        style={{ ...tooltipStyle, maxWidth: tooltipWidth }}
+      >
+        <div className="coach-tooltip-header">
+          <h3>{t(step.titleKey)}</h3>
+          <span className="coach-step-indicator">
+            {currentStep + 1} / {STEPS.length}
+          </span>
+        </div>
+        <p>{t(step.textKey)}</p>
+        <div className="coach-tooltip-actions">
+          <button className="coach-btn-skip" onClick={handleSkip}>
+            {t("coachSkip")}
+          </button>
+          <div className="coach-btn-group">
+            {currentStep > 0 && (
+              <button className="coach-btn-prev" onClick={handlePrev}>
+                {t("coachPrev")}
+              </button>
+            )}
+            <button className="coach-btn-next" onClick={handleNext}>
+              {currentStep === STEPS.length - 1 ? t("coachFinish") : t("coachNext")}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/i18n/translations.js
+++ b/web/src/i18n/translations.js
@@ -77,6 +77,24 @@ export const translations = {
     manualTitle: "User Manual",
     manualLoading: "Loading...",
     manualError: "Could not load user manual.",
+
+    // Coach Marks
+    coachSkip: "Skip tour",
+    coachPrev: "Back",
+    coachNext: "Next",
+    coachFinish: "Got it!",
+    coachWelcomeTitle: "Welcome!",
+    coachWelcomeText: "This app helps you track your baby's growth using WHO standards. Let's take a quick tour!",
+    coachNavTitle: "Navigation",
+    coachNavText: "Use these links to switch between the Calculator (single measurement), Evolution (charts over time), and User Manual.",
+    coachMetricTitle: "Choose a Metric",
+    coachMetricText: "Select what you want to measure: Weight, Height, or Head Circumference.",
+    coachGenderTitle: "Select Gender",
+    coachGenderText: "WHO growth charts differ by gender. Select your baby's gender here.",
+    coachLanguageTitle: "Language",
+    coachLanguageText: "You can switch between English and Spanish at any time.",
+    coachDisclaimerTitle: "Important",
+    coachDisclaimerText: "Remember: this tool is for reference only. Always consult your pediatrician for medical advice.",
   },
 
   es: {
@@ -157,6 +175,24 @@ export const translations = {
     manualTitle: "Manual de Usuario",
     manualLoading: "Cargando...",
     manualError: "No se pudo cargar el manual de usuario.",
+
+    // Coach Marks
+    coachSkip: "Saltar tour",
+    coachPrev: "Atrás",
+    coachNext: "Siguiente",
+    coachFinish: "¡Entendido!",
+    coachWelcomeTitle: "¡Bienvenido!",
+    coachWelcomeText: "Esta app te ayuda a seguir el crecimiento de tu bebé usando los estándares de la OMS. ¡Hagamos un tour rápido!",
+    coachNavTitle: "Navegación",
+    coachNavText: "Usa estos enlaces para cambiar entre la Calculadora (medida individual), Evolución (gráficos en el tiempo) y Manual de Usuario.",
+    coachMetricTitle: "Elige una Métrica",
+    coachMetricText: "Selecciona qué quieres medir: Peso, Altura o Perímetro Craneal.",
+    coachGenderTitle: "Selecciona el Sexo",
+    coachGenderText: "Las curvas de crecimiento de la OMS varían según el sexo. Selecciona el sexo de tu bebé aquí.",
+    coachLanguageTitle: "Idioma",
+    coachLanguageText: "Puedes cambiar entre inglés y español en cualquier momento.",
+    coachDisclaimerTitle: "Importante",
+    coachDisclaimerText: "Recuerda: esta herramienta es solo de referencia. Consulta siempre con tu pediatra para consejos médicos.",
   },
 };
 


### PR DESCRIPTION
- Create CoachMarks component with spotlight overlay and tooltips
- Guide users through 6 steps: welcome, navigation, metrics, gender, language, disclaimer
- Store completion status in localStorage (only shows once)
- Add translations for coach marks in English and Spanish
- Responsive design: tooltips fixed at bottom on mobile
- Animated spotlight with pulsing border effect

https://claude.ai/code/session_01PSh1yB4Ws6yw7HyUwJGQ2D