### PR TITLE
Add GitHub signature link to footer

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -338,6 +338,35 @@ body {
   text-decoration: underline;
 }
 
+/* GitHub signature */
+.github-signature {
+  text-align: center;
+  padding-top: 0.5rem;
+}
+
+.github-signature a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.6875rem;
+  color: var(--c-text-muted);
+  text-decoration: none;
+  transition: color var(--transition);
+}
+
+.github-signature a:hover {
+  color: var(--c-text-secondary);
+}
+
+.github-signature svg {
+  opacity: 0.7;
+  transition: opacity var(--transition);
+}
+
+.github-signature a:hover svg {
+  opacity: 1;
+}
+
 /* ── Content area ────────────────────────────────── */
 .content {
   flex: 1;

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -77,6 +77,14 @@ function GenderIcon() {
   );
 }
 
+function GitHubIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+    </svg>
+  );
+}
+
 function AppContent() {
   const { t, language, setLanguage } = useLanguage();
   const [measure, setMeasure] = useState("Weight");
@@ -188,6 +196,17 @@ function AppContent() {
             rel="noopener noreferrer"
           >
             {t("dataSourceLink")}
+          </a>
+        </div>
+
+        <div className="github-signature">
+          <a
+            href="https://github.com/albertferre"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <GitHubIcon />
+            <span>albertferre</span>
           </a>
         </div>
       </aside>


### PR DESCRIPTION
## Summary
Added a GitHub signature link to the application footer that credits the developer (albertferre) with a styled GitHub icon.

## Changes
- **CSS Styling** (`App.css`): Added `.github-signature` class with styling for:
  - Centered text alignment with subtle padding
  - Link styling with muted text color and smooth transitions
  - GitHub icon with opacity animation on hover
  - Hover state that brightens both text and icon

- **React Component** (`App.jsx`): 
  - Created new `GitHubIcon()` component that renders an SVG GitHub logo
  - Added GitHub signature section in the footer with a link to the developer's GitHub profile
  - Link opens in a new tab with security attributes (`target="_blank"` and `rel="noopener noreferrer"`)

## Implementation Details
- The signature uses existing CSS variables (`--c-text-muted`, `--c-text-secondary`, `--transition`) for consistency with the app's design system
- Icon and text are aligned using flexbox with a small gap between them
- Smooth transitions enhance the interactive experience on hover
- The GitHub icon SVG is inline for better performance and styling control

https://claude.ai/code/session_016v13aH1UewgWsdeb8X45DS