### PR TITLE
Fix onboarding tour: update language selector target

### DIFF
--- a/web/src/components/CoachMarks.jsx
+++ b/web/src/components/CoachMarks.jsx
@@ -35,7 +35,7 @@ const STEPS = [
     route: "/",
   },
   {
-    target: ".language-switcher",
+    target: ".language-dropdown",
     position: "bottom-left",
     titleKey: "coachLanguageTitle",
     textKey: "coachLanguageText",


### PR DESCRIPTION
Changed CoachMarks target from .language-switcher to .language-dropdown to match the new dropdown menu implementation.

https://claude.ai/code/session_01JcGZCAgdgnTPbWbp5DkA1a