### PR TITLE
Fix mobile settings panel for metric and gender selectors

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -362,6 +362,11 @@ select:focus-visible {
   gap: 1rem;
 }
 
+/* Mobile settings - hidden on desktop, shown on mobile */
+.mobile-settings {
+  display: none;
+}
+
 /* Sidebar sections */
 .sidebar-section {
   display: flex;
@@ -1907,6 +1912,24 @@ select:focus-visible {
   /* Show mobile settings panel */
   .mobile-settings {
     display: block;
+  }
+
+  .mobile-settings-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .mobile-settings .metric-toggle {
+    flex-direction: row;
+  }
+
+  .mobile-settings .metric-toggle button,
+  .mobile-settings .gender-toggle button {
+    flex: 1;
+    text-align: center;
+    min-height: 44px;
+    font-size: 0.8125rem;
   }
 
   .content {

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -325,6 +325,33 @@ function AppContent() {
             )}
           </div>
         </div>
+        <div className="mobile-settings">
+          <div className="mobile-settings-row">
+            <div className="metric-toggle">
+              {MEASURES.map((m) => (
+                <button
+                  key={m}
+                  className={measure === m ? "active" : ""}
+                  onClick={() => setMeasure(m)}
+                >
+                  {getMeasureLabel(m)}
+                </button>
+              ))}
+            </div>
+            <div className="gender-toggle">
+              {GENDERS.map((g) => (
+                <button
+                  key={g}
+                  className={gender === g ? `active-${g.toLowerCase()}` : ""}
+                  onClick={() => setGender(g)}
+                >
+                  {getGenderLabel(g)}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
         {data ? (
           <Routes>
             <Route


### PR DESCRIPTION
## Summary
- The sidebar settings (weight/height/head circumference and gender toggles) were hidden on mobile via `display: none` with no alternative UI, making it impossible to switch metrics on small screens
- Added a `.mobile-settings` panel inside the content area that renders horizontal metric and gender toggles, visible only on mobile (< 768px)
- Touch-friendly buttons with 44px min-height and responsive horizontal layout

## Test plan
- [ ] Open the app on a mobile device or browser at < 768px width
- [ ] Verify the metric toggle (Weight, Height, Head Circumference) is visible and functional
- [ ] Verify the gender toggle (Boys, Girls) is visible and functional
- [ ] Verify the settings panel is hidden on desktop (> 768px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)