### PR TITLE
Add version display and git version tags

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -267,6 +267,18 @@ select:focus-visible {
   -webkit-text-fill-color: transparent;
 }
 
+.app-version {
+  font-size: 0.625rem;
+  font-weight: 600;
+  color: var(--c-text-muted);
+  background: var(--c-bg-subtle);
+  padding: 0.125rem 0.5rem;
+  border-radius: 20px;
+  letter-spacing: 0.02em;
+  border: 1px solid var(--c-border-subtle);
+  white-space: nowrap;
+}
+
 /* Nav */
 .sidebar nav {
   display: flex;

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -189,6 +189,7 @@ function AppContent() {
             </svg>
           </div>
           <h2>{t("appTitle")}</h2>
+          <span className="app-version">v{__APP_VERSION__}</span>
         </div>
 
         <nav>

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { readFileSync } from 'fs'
+
+const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
 })


### PR DESCRIPTION
## Summary
- Display app version (`v1.0.0`) as a subtle badge in the sidebar next to the app title
- Inject version from `package.json` at build time via Vite's `define` option (`__APP_VERSION__`)
- Set `package.json` version to `1.0.0`
- Created annotated git tags for all historical versions: `v0.1.0` through `v1.0.0`

## Test plan
- [ ] Run `git tag -l` and verify all 6 version tags exist
- [ ] Run `npm run dev` in `web/` and verify the version badge appears in the sidebar
- [ ] Run `npm run build` and verify build succeeds
- [ ] Update `package.json` version and confirm the displayed version updates accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)